### PR TITLE
Define down_sample in the Skeletonizer docstring

### DIFF
--- a/pc_skeletor/skeletor.py
+++ b/pc_skeletor/skeletor.py
@@ -65,9 +65,13 @@ class Skeletonizer(object):
     def __init__(self, point_cloud: [o3d.geometry.PointCloud, str], debug: bool, down_sample: float = 0.005):
         '''
 
-        :param point_cloud:
-        :param debug:
-        :param down_sample:
+        :param point_cloud: Either an open3d PointCloud object, or a string
+            which should be a path to a point cloud file to open.
+        :param debug: Boolean, causes several pyplot windows to get shown to
+            debug the process.
+        :param down_sample: Performs voxel_down_sample on the given point cloud
+            before running contraction. Smaller values will result in smaller
+            voxels, which will take longer to run.
         '''
         if isinstance(point_cloud, str):
             self.pcd = load_pcd(filename=point_cloud, normalize=False)


### PR DESCRIPTION
I tried checking out the Skeletonizer help text in order to find out what `down_sample` does, but had to search in the source code to find out so I added an explanation in the docstring. Thanks for the useful library!

What the help text is currently:
```
In [5]: skeletor.Skeletonizer?
Init signature:
skeletor.Skeletonizer(
    point_cloud: [<class 'open3d.cpu.pybind.geometry.PointCloud'>, <class 'str'>],
    debug: bool,
    down_sample: float = 0.005,
)
Docstring:     
1. Laplacian based contraction.
    Paper: https://taiya.github.io/pubs/cao2010cloudcontr.pdf
    Code: https://github.com/taiya/cloudcontr
2. Source:
    Paper: https://www.cs.sfu.ca/~haoz/pubs/huang_sig13_l1skel.pdf
    Code: https://github.com/HongqiangWei/L1-Skeleton
Init docstring:
:param point_cloud:
:param debug:
:param down_sample:
File:           /usr/local/lib/python3.8/dist-packages/pc_skeletor/skeletor.py
Type:           type
```